### PR TITLE
check write errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -140,6 +140,17 @@ type option struct {
 	reverse bool
 }
 
+func writeString(w io.Writer, s string) error {
+	n, err := w.Write([]byte(s))
+	if err != nil {
+		return err
+	}
+	if n != len(s) {
+		return io.ErrShortWrite
+	}
+	return nil
+}
+
 func tate(w io.Writer, r io.Reader, o option) error {
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
@@ -194,9 +205,13 @@ func tate(w io.Writer, r io.Reader, o option) error {
 			} else {
 				s = "　"
 			}
-			w.Write([]byte(s))
+			if err := writeString(w, s); err != nil {
+				return err
+			}
 		}
-		w.Write([]byte("\n"))
+		if err := writeString(w, "\n"); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -33,5 +34,35 @@ func TestFail(t *testing.T) {
 	err := tate(&buf, &errReader{}, option{})
 	if err == nil {
 		t.Fatal("should be error")
+	}
+}
+
+type errWriter struct {
+	err error
+}
+
+func (w *errWriter) Write(b []byte) (int, error) {
+	return 0, w.err
+}
+
+func TestWriteFail(t *testing.T) {
+	want := errors.New("write failed")
+	err := tate(&errWriter{err: want}, strings.NewReader("x"), option{})
+	if !errors.Is(err, want) {
+		t.Fatalf("want %v, but %v", want, err)
+	}
+}
+
+type shortWriter struct {
+}
+
+func (w *shortWriter) Write(b []byte) (int, error) {
+	return len(b) - 1, nil
+}
+
+func TestShortWriteFail(t *testing.T) {
+	err := tate(&shortWriter{}, strings.NewReader("x"), option{})
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("want %v, but %v", io.ErrShortWrite, err)
 	}
 }


### PR DESCRIPTION
Return write failures from tate, including short writes, instead of silently reporting success.