### PR TITLE
handle voiced kana

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,6 +23,9 @@ const version = "0.0.9"
 var revision = "HEAD"
 
 var replacerHankana = strings.NewReplacer(
+	`ｳﾞ`, `ヴ`,
+	`ﾜﾞ`, `ヷ`,
+	`ｦﾞ`, `ヺ`,
 	`ｶﾞ`, `ガ`,
 	`ｷﾞ`, `ギ`,
 	`ｸﾞ`, `グ`,

--- a/main_test.go
+++ b/main_test.go
@@ -22,6 +22,19 @@ func TestTate(t *testing.T) {
 	}
 }
 
+func TestTateHalfwidthVoicedKana(t *testing.T) {
+	var buf bytes.Buffer
+	err := tate(&buf, strings.NewReader("ｳﾞﾜﾞｦﾞ\n"), option{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	want := "ヴ\nヷ\nヺ\n"
+	if got != want {
+		t.Fatalf("want %v, but %v", want, got)
+	}
+}
+
 type errReader struct {
 }
 


### PR DESCRIPTION
Handle halfwidth voiced kana pairs as single composed characters so vertical output does not split their dakuten into a separate row.