### PR TITLE
normalize input

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 
+	"golang.org/x/text/unicode/norm"
 	"golang.org/x/text/width"
 
 	"github.com/mattn/go-isatty"
@@ -173,6 +174,7 @@ func tate(w io.Writer, r io.Reader, o option) error {
 	s = strings.Replace(s, "\r", "", -1)
 	s = strings.Replace(s, "\t", "    ", -1)
 	s = strings.TrimRight(s, " 　\n")
+	s = norm.NFC.String(s)
 	lines := strings.Split(replacerUtf8.Replace(replacerHankana.Replace(s)), "\n")
 
 	if o.reverse {

--- a/main_test.go
+++ b/main_test.go
@@ -35,6 +35,19 @@ func TestTateHalfwidthVoicedKana(t *testing.T) {
 	}
 }
 
+func TestTateComposedVoicedKana(t *testing.T) {
+	var buf bytes.Buffer
+	err := tate(&buf, strings.NewReader("か\u3099\n"), option{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	want := "が\n"
+	if got != want {
+		t.Fatalf("want %v, but %v", want, got)
+	}
+}
+
 type errReader struct {
 }
 


### PR DESCRIPTION
Normalize input to NFC so decomposed dakuten sequences are handled as composed characters in vertical output.