### PR TITLE
fix punctuation

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,6 +61,8 @@ var replacerUtf8 = strings.NewReplacer(
 	`←`, `↑`,
 	`→`, `↓`,
 	`。`, `︒`,
+	`．`, `︒`,
+	`.`, `︒`,
 	`、`, `︑`,
 	`ー`, `｜`,
 	`─`, `｜`,
@@ -110,6 +112,7 @@ var replacerUtf8 = strings.NewReplacer(
 	`ｰ`, `|`,
 	`_`, `｜`,
 	`,`, `︐`,
+	`，`, `︐`,
 	`､`, `︑`,
 )
 

--- a/main_test.go
+++ b/main_test.go
@@ -74,6 +74,19 @@ func TestTateAsciiSymbols(t *testing.T) {
 	}
 }
 
+func TestTatePeriodComma(t *testing.T) {
+	var buf bytes.Buffer
+	err := tate(&buf, strings.NewReader(".．，\n"), option{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	want := "︒\n︒\n︐\n"
+	if got != want {
+		t.Fatalf("want %v, but %v", want, got)
+	}
+}
+
 type errReader struct {
 }
 


### PR DESCRIPTION
Convert ASCII and fullwidth periods and the fullwidth comma to their vertical punctuation forms.